### PR TITLE
This commit refactors the admin password reset feature based on your …

### DIFF
--- a/app.py
+++ b/app.py
@@ -1147,10 +1147,9 @@ def admin_reset_user_password():
     if not session.get("logged_in"): return redirect(url_for("login"))
     
     user_emoji = request.form.get("user_emoji")
-    new_password = request.form.get("new_password")
     
-    if not user_emoji or not new_password:
-        flash("Debe proporcionar tanto el emoji del usuario como la nueva contraseña", "error")
+    if not user_emoji:
+        flash("Debe proporcionar el emoji del usuario.", "error")
         return redirect(url_for("admin_configuracion"))
     
     usuarios = cargar_usuarios()
@@ -1158,11 +1157,12 @@ def admin_reset_user_password():
         flash(f"No se encontró un usuario con el emoji: {user_emoji}", "error")
         return redirect(url_for("admin_configuracion"))
     
-    # Reiniciar la contraseña
-    usuarios[user_emoji]["password_hash"] = generate_password_hash(new_password)
+    # Reiniciar la contraseña a un valor por defecto
+    default_password = "1234"
+    usuarios[user_emoji]["password_hash"] = generate_password_hash(default_password)
     guardar_usuarios(usuarios)
     
-    flash(f"Contraseña reiniciada exitosamente para el usuario {user_emoji}", "success")
+    flash(f"La contraseña para el usuario {user_emoji} ha sido reiniciada a '{default_password}'.", "success")
     return redirect(url_for("admin_configuracion"))
 
 @app.route("/admin/reset-user-account", methods=["POST"])

--- a/templates/admin_config.html
+++ b/templates/admin_config.html
@@ -241,7 +241,7 @@
                 <form method="POST" action="{{ url_for('admin_reset_user_password') }}" style="display: flex; flex-direction: column; gap: 10px;">
                     <label style="color: #ff6666; font-size: 10px;">🔑 Reiniciar Contraseña de Usuario:</label>
                     <input type="text" name="user_emoji" placeholder="Emoji del usuario (ej: 😀)" style="padding: 8px; background: #333; border: 2px solid #555; color: #fff; border-radius: 5px; font-family: 'Press Start 2P', cursive; font-size: 10px;">
-                    <input type="password" name="new_password" placeholder="Nueva contraseña" style="padding: 8px; background: #333; border: 2px solid #555; color: #fff; border-radius: 5px; font-family: 'Press Start 2P', cursive; font-size: 10px;">
+                    <div class="help-text">La contraseña se reiniciará a un valor por defecto ('1234').</div>
                     <button type="submit" onclick="return confirm('¿Estás seguro de reiniciar la contraseña de este usuario?')" style="background: #ff3333; color: #fff; border: 2px solid #ff6666; padding: 8px 15px; border-radius: 5px; font-family: 'Press Start 2P', cursive; font-size: 9px; cursor: pointer;">🔄 Reiniciar Contraseña</button>
                 </form>
                 


### PR DESCRIPTION
…feedback.

The requirement to manually enter a new password has been removed. Administrators can now reset a user's password with a single click.

The changes include:
- The 'new_password' input field was removed from the form in `templates/admin_config.html`.
- The `admin_reset_user_password` route in `app.py` was updated to set a hardcoded default password ('1234') for the user.
- The flash message was updated to inform the admin of the new temporary password.