### PR TITLE
feat: Add admin action to reset all users

### DIFF
--- a/app.py
+++ b/app.py
@@ -1158,6 +1158,25 @@ def admin_configuracion():
             guardar_pedidos([])
             flash(f"TODOS los pedidos han sido eliminados. Se creó una copia de respaldo: {backup_filename}", "success")
 
+        elif action == "reset_all_users":
+            usuarios = cargar_usuarios()
+            default_password = "1234"
+            hashed_password = generate_password_hash(default_password)
+
+            for user_emoji in usuarios:
+                # Mantener la estructura de datos, pero reiniciar valores
+                usuarios[user_emoji]["password_hash"] = hashed_password
+                usuarios[user_emoji]["aura_points"] = 0
+
+                # Usar .get para evitar errores si la clave no existe
+                if "claimed_levels" in usuarios[user_emoji]:
+                    usuarios[user_emoji]["claimed_levels"] = []
+                if "reward_codes" in usuarios[user_emoji]:
+                    del usuarios[user_emoji]["reward_codes"]
+
+            guardar_usuarios(usuarios)
+            flash("TODOS los usuarios han sido reseteados. Sus contraseñas ahora son '1234'.", "success")
+
         return redirect(url_for("admin_configuracion"))
     
     return render_template("admin_config.html", config=cargar_configuracion())

--- a/templates/admin_config.html
+++ b/templates/admin_config.html
@@ -92,6 +92,15 @@
                         </div>
                         <button type="submit" name="action" value="clear_orders" onclick="return confirm('¿ESTÁS COMPLETAMENTE SEGURO? Esta acción eliminará TODOS los pedidos y NO SE PUEDE DESHACER.')" class="submit-btn" style="background: #aa0000; border-color: #ff3333; color: #fff; margin-top: 10px;">💥 BORRAR TODOS LOS PEDIDOS</button>
                     </div>
+
+                    <!-- Resetear todos los usuarios -->
+                    <div class="form-group">
+                        <label style="color: #ff6666; font-size: 10px;">🔄 Resetear Todos los Usuarios y Contraseñas:</label>
+                        <div style="background: #2a1a1a; padding: 10px; border: 2px solid #ff3333; border-radius: 5px; font-size: 8px; color: #ff6666;">
+                            ⚠️ ADVERTENCIA: Esta acción reiniciará los puntos, niveles y contraseñas (a '1234') de TODOS los usuarios. Es irreversible.
+                        </div>
+                        <button type="submit" name="action" value="reset_all_users" onclick="return confirm('¿ESTÁS COMPLETAMENTE SEGURO? Esta acción reiniciará a TODOS los usuarios y sus contraseñas. NO SE PUEDE DESHACER.')" class="submit-btn" style="background: #aa0000; border-color: #ff3333; color: #fff; margin-top: 10px;">💥 RESETEAR TODOS LOS USUARIOS</button>
+                    </div>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
This commit introduces a new administrative feature to reset all user accounts.

- Adds a "Reset All Users" button to the admin configuration page (`/admin/configuracion`).
- The button is styled as a destructive action and requires a confirmation dialog.
- Implements the backend logic in the `admin_configuracion` route to handle the action.
- When triggered, the feature iterates through all users in `usuarios.json`, resets their `aura_points` and `claimed_levels` to default values, and sets their password to a default ('1234').
- This provides a quick way for an administrator to perform a full user data reset without affecting order history.