### PR TITLE
refactor: Change password reset to require new password on login

### DIFF
--- a/templates/admin_config.html
+++ b/templates/admin_config.html
@@ -97,7 +97,7 @@
                     <div class="form-group">
                         <label style="color: #ff6666; font-size: 10px;">🔄 Resetear Todos los Usuarios y Contraseñas:</label>
                         <div style="background: #2a1a1a; padding: 10px; border: 2px solid #ff3333; border-radius: 5px; font-size: 8px; color: #ff6666;">
-                            ⚠️ ADVERTENCIA: Esta acción reiniciará los puntos, niveles y contraseñas (a '1234') de TODOS los usuarios. Es irreversible.
+                            ⚠️ ADVERTENCIA: Esta acción reiniciará los puntos, niveles y contraseñas (el usuario deberá crear una nueva al iniciar sesión) de TODOS los usuarios. Es irreversible.
                         </div>
                         <button type="submit" name="action" value="reset_all_users" onclick="return confirm('¿ESTÁS COMPLETAMENTE SEGURO? Esta acción reiniciará a TODOS los usuarios y sus contraseñas. NO SE PUEDE DESHACER.')" class="submit-btn" style="background: #aa0000; border-color: #ff3333; color: #fff; margin-top: 10px;">💥 RESETEAR TODOS LOS USUARIOS</button>
                     </div>


### PR DESCRIPTION
I have refactored the "Reset All Users" administrative feature based on your feedback.

- Instead of resetting passwords to a default value ('1234'), the `password_hash` is now set to `null` in `usuarios.json`.
- The `emoji_access` login route has been updated. If a user's `password_hash` is `null`, the first password they enter is hashed and becomes their new password, logging them in immediately.
- The warning text on the admin configuration page has been updated to reflect this new, more secure behavior.
- The new user creation logic in `emoji_access` is also updated to be more consistent with the user data model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users whose passwords have been reset by an admin can now set a new password upon their next login.
  * New users registering with an emoji now have their claimed levels initialized.

* **Bug Fixes**
  * Updated admin reset functionality so that users must create a new password instead of receiving a default one.

* **Documentation**
  * Clarified admin panel warning text to indicate that users will need to create a new password after a reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->