### PR TITLE
Adjust EmojiLogin container classes and sizing behavior

### DIFF
--- a/web/src/pages/EmojiLogin.tsx
+++ b/web/src/pages/EmojiLogin.tsx
@@ -37,7 +37,7 @@ const EmojiLogin = () => {
   };
 
   return (
-    <div className="relative w-full h-screen bg-black">
+    <div className="w-full h-screen overflow-hidden">
       <MatrixBackground />
 
       <div className="login-container">

--- a/web/src/styles/style.css
+++ b/web/src/styles/style.css
@@ -142,10 +142,8 @@ h2 {
 /* ============================================= */
 .login-container {
   position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-
+  inset: 0;
+  margin: auto;
   background: rgba(0, 0, 0, 0.55);
   backdrop-filter: blur(6px);
 
@@ -163,6 +161,8 @@ h2 {
 
   width: 90%;
   max-width: 420px;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
 }
 
 .emoji-grid {


### PR DESCRIPTION
### Motivation
- Fix layout issues so the `MatrixBackground` canvas can span the full viewport and the login UI behaves correctly on small screens.
- Make `.login-container` centering more robust and allow the login card to scroll when viewport height is constrained.

### Description
- Replaced the root wrapper in `web/src/pages/EmojiLogin.tsx` from `relative w-full h-screen bg-black` to `w-full h-screen overflow-hidden` to let the background canvas fill the screen and avoid an extra black layer.
- Updated `.login-container` in `web/src/styles/style.css` to use `inset: 0;` and `margin: auto;` instead of `top/left/transform` centering to simplify positioning.
- Added `max-height: calc(100vh - 2rem);` and `overflow-y: auto;` to `.login-container` to improve usability on small viewports.
- Changes applied to `web/src/pages/EmojiLogin.tsx` and `web/src/styles/style.css` and committed.

### Testing
- Ran `git diff --check` which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05649f304832faa3fb284bf5d0e5e)