### PR TITLE
Arreglar centrado del login emoji y carga de CSS global en producción

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,6 +1,5 @@
+@import './styles/style.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* 👇 aquí importas tu estilo RPG */
-@import './styles/style.css';

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,7 +7,7 @@ import Admin from './pages/Admin';
 import EmojiLogin from './pages/EmojiLogin';
 import Profile from './pages/Profile';
 import Settings from './pages/Settings';
-import './styles/style.css';
+import './index.css';
 
 const router = createBrowserRouter([
   { path: '/', element: <Home /> },

--- a/web/src/styles/style.css
+++ b/web/src/styles/style.css
@@ -142,27 +142,23 @@ h2 {
 /* ============================================= */
 .login-container {
   position: fixed;
-  inset: 0;
-  margin: auto;
-  background: rgba(0, 0, 0, 0.55);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(6px);
 
   border: 2px solid #33ff33;
-  border-radius: 12px;
+  border-radius: 10px;
 
-  padding: 25px;
+  padding: 20px;
   text-align: center;
 
   z-index: 20;
 
-  box-shadow:
-    0 0 20px rgba(0, 255, 0, 0.6),
-    0 0 40px rgba(0, 255, 0, 0.3);
-
   width: 90%;
   max-width: 420px;
-  max-height: calc(100vh - 2rem);
-  overflow-y: auto;
+  box-shadow: 0 0 20px rgba(0, 255, 0, 0.5);
 }
 
 .emoji-grid {


### PR DESCRIPTION
### Motivation

- En producción los estilos globales no se estaban aplicando correctamente y el login aparecía fuera de lugar por problemas de orden de importación y reglas CSS que dependían de Tailwind.
- También había riesgo de marcas de conflicto Git o llaves mal cerradas en los estilos que podían romper el build o la apariencia en Vercel.

### Description

- Cambié el entrypoint de estilos en `web/src/main.tsx` para importar `index.css` en lugar de `styles/style.css`, unificando la carga de Tailwind y estilos globales desde un único punto (`web/src/main.tsx`).
- Moví `@import './styles/style.css';` al inicio de `web/src/index.css` antes de las directivas `@tailwind` para corregir el orden y evitar el warning de Vite sobre `@import` que podía provocar la pérdida de estilos en producción.
- Actualicé `.login-container` en `web/src/styles/style.css` para usar centrado fijo con `top: 50%`, `left: 50%` y `transform: translate(-50%, -50%)`, ajusté `background`, `backdrop-filter`, `border`, `border-radius`, `padding`, `z-index`, `box-shadow`, `width` y `max-width` para coincidir con el diseño solicitado.
- Verifiqué que `EmojiLogin.tsx` ya usa `className="w-full h-screen overflow-hidden"` y que `MatrixBackground.tsx` sitúa el canvas detrás con `className="fixed top-0 left-0 w-full h-full -z-10 bg-black"`, por lo que no se modificó la lógica del login.

### Testing

- Ejecuté `rg -n "^(<<<<<<<|=======|>>>>>>>)" web/src` y no se encontraron marcas de conflicto (éxito).
- Ejecuté `cd web && npm run build`; la primera compilación mostró un warning de orden de `@import` y fue diagnosticado, luego tras mover el `@import` la compilación se completó correctamente sin warnings relevantes (éxito tras corrección).
- Confirmé cambios en el repositorio con `git status` y realicé el commit `Fix emoji login layout and global CSS loading` (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05ad32438832fa89cd6c736036027)