### PR TITLE
Fix Matrix background layering and translucent login styling

### DIFF
--- a/web/src/components/MatrixBackground.tsx
+++ b/web/src/components/MatrixBackground.tsx
@@ -80,10 +80,9 @@ const MatrixBackground: React.FC = () => {
   return (
     <canvas
       ref={canvasRef}
-      className="fixed top-0 left-0 w-full h-full -z-10 bg-black"
+      className="fixed top-0 left-0 w-full h-full z-0 bg-black"
     />
   );
 };
 
 export default MatrixBackground;
-

--- a/web/src/styles/style.css
+++ b/web/src/styles/style.css
@@ -145,8 +145,11 @@ h2 {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(6px);
+  z-index: 10;
+
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   border: 2px solid #33ff33;
   border-radius: 10px;
@@ -154,11 +157,15 @@ h2 {
   padding: 20px;
   text-align: center;
 
-  z-index: 20;
-
   width: 90%;
   max-width: 420px;
-  box-shadow: 0 0 20px rgba(0, 255, 0, 0.5);
+  box-shadow: 0 0 20px rgba(0, 255, 0, 0.6);
+}
+
+@supports not ((-webkit-backdrop-filter: blur(8px)) or (backdrop-filter: blur(8px))) {
+  .login-container {
+    background: rgba(0, 0, 0, 0.7);
+  }
 }
 
 .emoji-grid {


### PR DESCRIPTION
### Motivation
- Restore the animated Matrix canvas behind the login and recover a translucent, blurred “glass” login container while keeping the login centered.
- Avoid hiding the canvas behind the page by removing a negative z-index and provide a robust blur experience across deployments (e.g., Vercel/Safari).

### Description
- Changed the Matrix canvas class in `web/src/components/MatrixBackground.tsx` from `-z-10` to `z-0` so the animation remains visible behind page content.
- Updated `.login-container` in `web/src/styles/style.css` to set `z-index: 10`, use `background: rgba(0, 0, 0, 0.5)` with `backdrop-filter: blur(8px)` and `-webkit-backdrop-filter: blur(8px)`, and tuned the glow shadow.
- Added an `@supports not (...)` CSS fallback that applies `background: rgba(0, 0, 0, 0.7)` when backdrop blur is not available.
- No application logic was modified and `EmojiLogin.tsx` already uses the intended structure (`overflow-hidden`, `<MatrixBackground />`, and the `.login-container` above it).

### Testing
- No automated unit or end-to-end test suite was executed for these UI-only changes.
- Performed repository verification via `git diff -- web/src/components/MatrixBackground.tsx web/src/styles/style.css web/src/pages/EmojiLogin.tsx` and `git status --short`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05c910028832fa7aaad3bba97898f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined visual layering and stacking order of background elements across the application to improve overall page depth and design composition.
  * Enhanced login modal appearance with more refined backdrop blur effects, adjusted background transparency levels, refined glow and shadow effects, and improved compatibility for users with browsers that have varying levels of support for advanced visual effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->