### PR TITLE
Fix Supabase emoji login flow and error handling

### DIFF
--- a/web/src/pages/EmojiLogin.tsx
+++ b/web/src/pages/EmojiLogin.tsx
@@ -1,39 +1,67 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import MatrixBackground from '../components/MatrixBackground';
+import { supabase } from '../lib/supabaseClient';
+
+const EMOJI_AVATARS = ['😀', '🚀', '👻', '🌵', '🎮', '💎', '👽', '💀', '🤖', '🦊', '🐱', '🐼'];
 
 const EmojiLogin = () => {
   const [emojis, setEmojis] = useState<string[]>([]);
   const [selectedEmoji, setSelectedEmoji] = useState<string | null>(null);
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // A hardcoded list of emojis as a fallback or for initial display
-  const EMOJI_AVATARS = ['😀', '🚀', '👻', '🌵', '🎮', '💎', '👽', '💀', '🤖', '🦊', '🐱', '🐼'];
-
   useEffect(() => {
-    // You can replace this with a fetch call if needed
     setEmojis(EMOJI_AVATARS);
   }, []);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setSuccess(null);
+
     if (!selectedEmoji) {
       setError('Por favor, selecciona un emoji.');
       return;
     }
+
+    if (!password.trim()) {
+      setError('Por favor, ingresa tu contraseña.');
+      return;
+    }
+
     setLoading(true);
-    console.log(`Logging in with ${selectedEmoji} and password ${password}`);
-    // Mock login logic
-    setTimeout(() => {
-      setLoading(false);
-      if (password === '123') {
-        alert('Login successful!');
-      } else {
-        setError('Contraseña incorrecta.');
+
+    try {
+      const { data, error: queryError } = await supabase
+        .from('users')
+        .select('*')
+        .eq('emoji', selectedEmoji)
+        .eq('password', password)
+        .single();
+
+      if (queryError) {
+        if (queryError.code === 'PGRST116') {
+          setError('Usuario no encontrado');
+        } else {
+          setError(queryError.message || 'Error desconocido en el login.');
+        }
+        return;
       }
-    }, 1000);
+
+      if (!data) {
+        setError('Usuario no encontrado');
+        return;
+      }
+
+      setSuccess('Login exitoso');
+    } catch (unexpectedError) {
+      const message = unexpectedError instanceof Error ? unexpectedError.message : 'Error inesperado en el login.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -68,6 +96,7 @@ const EmojiLogin = () => {
           </div>
 
           {error && <p className="text-red-500 mt-3">{error}</p>}
+          {success && <p className="text-green-400 mt-3">{success}</p>}
 
           <button
             type="submit"


### PR DESCRIPTION
### Motivation
- Corregir el sistema de login que siempre fallaba para que use correctamente Supabase y consulte la tabla `users` buscando por `emoji` y `password` con manejo de errores real.

### Description
- Cambié `web/src/pages/EmojiLogin.tsx` para importar el cliente Supabase desde `../lib/supabaseClient` y eliminar la lógica mock existente.
- Implementé la consulta recomendada usando `await supabase.from('users').select('*').eq('emoji', selectedEmoji).eq('password', password).single()` y procesé la respuesta correctamente.
- Añadí validaciones de formulario para emoji y contraseña, manejo de estado `loading`, y estados `error` y `success` para feedback en la UI.
- Manejo explícito de errores mostrando `Usuario no encontrado` cuando no hay coincidencia y mostrando el mensaje real de Supabase para otros errores; también se captura cualquier excepción inesperada.

### Testing
- Ejecuté `npm run build` en `web/` (Vite build) y la compilación completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b1887858832f9faa602081e9a23b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Login now uses real authentication instead of mock verification.
  * Enhanced error handling with clear, user-facing error messages.
  * Added login success confirmation display for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->