### PR TITLE
Alinear inicialización de cliente Supabase con el snippet esperado

### DIFF
--- a/web/src/lib/supabaseClient.ts
+++ b/web/src/lib/supabaseClient.ts
@@ -3,11 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error("Supabase URL and Anon Key must be defined in .env");
-}
-
-console.log("URL:", supabaseUrl);
-console.log("KEY:", supabaseAnonKey);
+console.log("SUPABASE URL:", supabaseUrl);
+console.log("SUPABASE KEY:", supabaseAnonKey);
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
### Motivation
- Asegurar que la inicialización del cliente de Supabase siga exactamente el snippet esperado en Vite para facilitar el debug de problemas de conexión/DNS y verificar las variables de entorno usadas por la app web.

### Description
- Actualicé `web/src/lib/supabaseClient.ts` para que lea directamente `import.meta.env.VITE_SUPABASE_URL` y `import.meta.env.VITE_SUPABASE_ANON_KEY`, elimine la verificación que lanzaba un `Error` en tiempo de ejecución y muestre los `console.log` con las etiquetas `SUPABASE URL` y `SUPABASE KEY`, manteniendo la exportación `createClient(supabaseUrl, supabaseAnonKey)`.

### Testing
- Verifiqué y validé el archivo actualizado con los comandos de lectura y escritura (`sed -n`, escritura por here-doc y `nl -ba`) y confirmé la presencia del archivo con `rg`, y todos los comandos de verificación finalizaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b5d09fd4832fb8d659c310d0203b)