### PR TITLE
feat(web): add Tibia-style CharacterPanel component

### DIFF
--- a/web/src/components/CharacterPanel.tsx
+++ b/web/src/components/CharacterPanel.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import '../styles/character-panel.css';
+
+export type EquipmentType = 'helmet' | 'armor' | 'weapon' | 'shield' | 'boots' | 'ring';
+
+export interface CharacterItem {
+  image: string;
+  type: EquipmentType;
+  aura: number;
+}
+
+interface CharacterPanelProps {
+  initialInventory?: CharacterItem[];
+  initialLevel?: number;
+  initialExp?: number;
+}
+
+const CharacterPanel: React.FC<CharacterPanelProps> = ({
+  initialInventory = [],
+  initialLevel = 1,
+  initialExp = 0,
+}) => {
+  const [equipment, setEquipment] = useState<Record<EquipmentType, string | null>>({
+    helmet: null,
+    armor: null,
+    weapon: null,
+    shield: null,
+    boots: null,
+    ring: null,
+  });
+
+  const [inventory, setInventory] = useState<CharacterItem[]>(initialInventory);
+  const [exp, setExp] = useState(initialExp);
+  const [level, setLevel] = useState(initialLevel);
+
+  const equipItem = (item: CharacterItem) => {
+    setEquipment((prev) => ({
+      ...prev,
+      [item.type]: item.image,
+    }));
+  };
+
+  const consumeItem = (index: number) => {
+    const item = inventory[index];
+    if (!item) return;
+
+    setExp((prev) => {
+      const newExp = prev + item.aura;
+
+      if (newExp >= 100) {
+        setLevel((l) => l + 1);
+        return newExp - 100;
+      }
+
+      return newExp;
+    });
+
+    setInventory((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="character-panel">
+      <div className="character-header">
+        <span>Nivel {level}</span>
+      </div>
+
+      <div className="character-body">
+        <div className="equipment-grid">
+          <div className="slot helmet">
+            {equipment.helmet && <img src={equipment.helmet} alt="Helmet" />}
+          </div>
+          <div className="slot armor">
+            {equipment.armor && <img src={equipment.armor} alt="Armor" />}
+          </div>
+          <div className="slot weapon">
+            {equipment.weapon && <img src={equipment.weapon} alt="Weapon" />}
+          </div>
+          <div className="slot shield">
+            {equipment.shield && <img src={equipment.shield} alt="Shield" />}
+          </div>
+          <div className="slot boots">
+            {equipment.boots && <img src={equipment.boots} alt="Boots" />}
+          </div>
+          <div className="slot ring">
+            {equipment.ring && <img src={equipment.ring} alt="Ring" />}
+          </div>
+        </div>
+
+        <div className="backpack">
+          {inventory.map((item, i) => (
+            <button
+              type="button"
+              className="inventory-slot"
+              key={`${item.type}-${item.image}-${i}`}
+              onClick={() => consumeItem(i)}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                equipItem(item);
+              }}
+              title="Click: consumir aura | Click derecho: equipar"
+            >
+              <img src={item.image} alt={item.type} />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="exp-bar">
+        <div className="exp-fill" style={{ width: `${exp}%` }} />
+      </div>
+    </div>
+  );
+};
+
+export default CharacterPanel;

--- a/web/src/styles/character-panel.css
+++ b/web/src/styles/character-panel.css
@@ -1,0 +1,74 @@
+.character-panel {
+  width: 260px;
+  background: #2a2a2a;
+  border: 3px solid #888;
+  padding: 10px;
+  color: #fff;
+}
+
+.character-header {
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+.character-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.equipment-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 60px);
+  gap: 6px;
+  justify-content: center;
+}
+
+.slot {
+  width: 60px;
+  height: 60px;
+  background: #111;
+  border: 2px solid #555;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.slot img {
+  width: 90%;
+  height: 90%;
+  object-fit: contain;
+}
+
+.backpack {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: repeat(4, 50px);
+  gap: 5px;
+}
+
+.inventory-slot {
+  width: 50px;
+  height: 50px;
+  background: #111;
+  border: 1px solid #444;
+  padding: 0;
+  cursor: pointer;
+}
+
+.inventory-slot img {
+  width: 100%;
+  height: 100%;
+}
+
+.exp-bar {
+  margin-top: 10px;
+  height: 10px;
+  background: #000;
+  border: 1px solid #666;
+}
+
+.exp-fill {
+  height: 100%;
+  background: lime;
+}


### PR DESCRIPTION
### Motivation

- Añadir un HUD lateral estilo MMORPG/Tibia que muestre nivel, panel de equipamiento, backpack e indicador de experiencia.

### Description

- Se añadió el componente React `web/src/components/CharacterPanel.tsx` con estado local para `equipment`, `inventory`, `exp` y `level` y las funciones `equipItem` y `consumeItem`.
- El componente renderiza los slots de equipamiento (`helmet`, `armor`, `weapon`, `shield`, `boots`, `ring`), una rejilla de backpack y una barra de experiencia con rollover de EXP al subir de nivel.
- Se creó la hoja de estilos `web/src/styles/character-panel.css` y se importó desde el componente para aplicar el estilo tipo Tibia.
- Las interacciones del inventario están implementadas como: click izquierdo para consumir (ganar aura/EXP) y click derecho para equipar el ítem.

### Testing

- Se ejecutó `npm run build` dentro de `web/` y la compilación fue satisfactoria.
- Se ejecutó `npm run build --silent` dentro de `web/` y la compilación fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c9275ef0832f807c4774826bc9bb)